### PR TITLE
feat: Implement Util to Filter Rows by Search Field

### DIFF
--- a/src/utils/filter2DArrayRows.js
+++ b/src/utils/filter2DArrayRows.js
@@ -1,0 +1,26 @@
+/**
+ * Filters rows of a 2D array based on a single field and search value (case-insensitive, partial match).
+ *
+ * @param {Array[]} data - 2D array including headers in the first row.
+ * @param {string} searchField - The header name of the column to search in.
+ * @param {string} searchValue - The value to search for (case-insensitive, partial match).
+ * @returns {Array[]} Filtered array of rows, including headers. Returns an empty array if no matches found.
+ */
+function filter2DArrayRows(data, searchField, searchValue) {
+    if (data.length === 0) return [];
+  
+    const headers = data[0];
+    const fieldIndex = headers.indexOf(searchField);
+
+    if (fieldIndex === -1) {
+      throw new Error(`Field "${searchField}" not found in headers.`);
+    }
+
+    const matches = data.slice(1).filter(row => 
+      String(row[fieldIndex]).toLowerCase().includes(searchValue.toLowerCase())
+    );
+    
+    return matches.length ? [headers, ...matches] : []
+}
+
+module.exports = { filter2DArrayRows };

--- a/tests/utils/filter2DArrayRows.test.js
+++ b/tests/utils/filter2DArrayRows.test.js
@@ -1,0 +1,67 @@
+const { filter2DArrayRows } = require("../../src/utils/filter2DArrayRows");
+
+const testData = [
+    ['ID', 'Company', 'Location'],
+    [1, 'Amazon.com', 'Seattle'],
+    [2, 'Google', 'Seattle'],
+    [3, 'Microsoft', 'Redmond']
+];
+
+describe('filter2DArrayRows', () => {
+    it('filters single matching row', () => {
+        const searchField = 'Company';
+        const searchValue = 'Amazon.com';
+
+        result = filter2DArrayRows(testData, searchField, searchValue);
+
+        expect(result).toEqual([
+            ['ID', 'Company', 'Location'],
+            [1, 'Amazon.com', 'Seattle']
+        ]);
+    });
+
+    it('filters multiple matching rows', () => {
+        const searchField = 'Location';
+        const searchValue = 'Seattle';
+
+        result = filter2DArrayRows(testData, searchField, searchValue);
+
+        expect(result.length).toBe(3);
+    });
+
+    it('filters case insensitive', () => {
+        const searchField = 'Location';
+        const searchValue = 'seattle';
+
+        result = filter2DArrayRows(testData, searchField, searchValue);
+
+        expect(result.length).toBe(3);
+    });
+
+    it('filters for partial match', () => {
+        const searchField = 'Location';
+        const searchValue = 'sea';
+
+        result = filter2DArrayRows(testData, searchField, searchValue);
+
+        expect(result.length).toBe(3);
+    });
+
+    it('returns empty array when no match', () => {
+        const searchField = 'Location';
+        const searchValue = 'San Francisco';
+
+        result = filter2DArrayRows(testData, searchField, searchValue);
+
+        expect(result.length).toBe(0);
+    });
+
+    it('throws error if search field not found', () => {
+        const searchField = 'Invalid';
+        const searchValue = 'Hello world';
+
+        expect(() => {
+            filter2DArrayRows(testData, searchField, searchValue);
+        }).toThrow('Field "Invalid" not found in headers.');
+    });
+});


### PR DESCRIPTION
Adds a `filter2DArrayRows` util to return matching rows from a 2D array that match the `searchValue` in the `searchField`. This will be used to search sheets for these use cases:
- find Application ID to log related models
- find Consideration details (first finding the Application ID to search with)
- find all Applications for a Company