### PR TITLE
fix: Related logger missing application id when not passed in

### DIFF
--- a/src/loggers/relatedLogger.js
+++ b/src/loggers/relatedLogger.js
@@ -44,6 +44,10 @@ function relatedLoggerWorkflow({
     const uiSheetName = relatedName + 'Logger'
     const appSearchInputsRangeName = uiSheetName + '_AppSearchInputs';
 
+    if (!applicationId) {
+        applicationId = getApplicationId(appSearchInputsRangeName);
+    }
+
     const modelInputsRangeName = uiSheetName + '_ModelInputs';
     const inputsMap = getInputsFromSheetUI(modelInputsRangeName);
     validateInputs(inputsMap, requiredFields);


### PR DESCRIPTION
Fixes a bug that was introduced when integrating the logger for considerations. That logger required use of the application ID which was fetched by the related logger workflow downstream, so it was added as an optional parameter to fetch it and use it in the consideration logger and avoid re-fetching it in the related logger. However, fetching it in the related logger was entire removed by mistake instead of fetching when it was not passed in.