### PR TITLE
feat: Implement interview logger workflow with UUID prefix support

### DIFF
--- a/src/loggers/interviewLogger.js
+++ b/src/loggers/interviewLogger.js
@@ -1,0 +1,26 @@
+const { relatedLoggerWorkflow } = require("./relatedLogger");
+
+function onInterviewLoggerLogClick() {
+    const requiredFields = [
+        'Stage',
+        'Type',
+        'Interview Date',
+        'Interviewer Title',
+        'Interviewer Name',
+    ];
+
+    const defaultsMap = {
+        'Stage': 'Recruiter Screen',
+        'Type': 'Video Call',
+        'Interviewer Title': 'Recruiter'
+    };
+
+    const prefixValues = [Utilities.getUuid()];
+
+    relatedLoggerWorkflow({
+        relatedName: 'Interview',
+        requiredFields: requiredFields,
+        defaultsMap: defaultsMap,
+        prefixValues: prefixValues
+    })
+}

--- a/src/loggers/relatedLogger.js
+++ b/src/loggers/relatedLogger.js
@@ -39,6 +39,7 @@ function relatedLoggerWorkflow({
     requiredFields,
     subsetClearFields = [],
     defaultsMap = {},
+    prefixValues = [],
     suffixValues = []
 }) {
     const uiSheetName = relatedName + 'Logger'
@@ -52,7 +53,7 @@ function relatedLoggerWorkflow({
     const inputsMap = getInputsFromSheetUI(modelInputsRangeName);
     validateInputs(inputsMap, requiredFields);
 
-    const rowValues = generateRowValues(inputsMap, [applicationId], suffixValues);
+    const rowValues = generateRowValues(inputsMap, [...prefixValues, applicationId], suffixValues);
     const dataSheetName = relatedName + 's';
     appendRowToSheet(dataSheetName, rowValues);
 


### PR DESCRIPTION
## Related Issue
N/A

## Problem
There was no dedicated logger workflow for recording interview-related events in the system. Additionally, interview logs needed to support the automatic generation of a UUID as a prefix value for traceability.

## Changes
- Introduced `onInterviewLoggerLogClick` function in `interviewLogger.js` to handle interview log events, specifying required fields, default values, and a generated UUID prefix.
- Updated `relatedLoggerWorkflow` in `relatedLogger.js` to support `prefixValues`, prepending them to the row values when logging data.

## Testing
- Verified that triggering `onInterviewLoggerLogClick` appends a new row to the `Interviews` sheet with a UUID prefix.
- Confirmed required fields validation and default value assignment.
- Confirmed that existing workflows without `prefixValues` continue to function as expected.

## Value
Introduces a dedicated interview logger workflow, improving the system’s ability to record structured, traceable interview events with unique identifiers for future relationship mapping and analysis.
