### PR TITLE
feat: add toggle to optionally retain inputs after logging in relatedLogger

### DIFF
--- a/src/loggers/relatedLogger.js
+++ b/src/loggers/relatedLogger.js
@@ -59,8 +59,11 @@ function relatedLoggerWorkflow({
     const dataSheetName = relatedName + 's';
     appendRowToSheet(dataSheetName, rowValues);
 
-    resetSheetUI(modelInputsRangeName, subsetClearFields, defaultsMap);
-    resetSheetUI(appSearchInputsRangeName);
+    const clearInputsAfterLogging = getNamedRangeValue(uiSheetName + '_ClearInputsAfterLogging');
+    if (clearInputsAfterLogging === true) {
+        resetSheetUI(modelInputsRangeName, subsetClearFields, defaultsMap);
+        resetSheetUI(appSearchInputsRangeName);
+    }
 
     const hideAfterLogging = getNamedRangeValue(uiSheetName + '_HideAfterLogging');
     if (hideAfterLogging === true) {


### PR DESCRIPTION
**Related Issue**  
N/A

---

**Problem**  
Previously, the logger always cleared input fields after each log submission to prevent stale data from being left in the sheet. This worked well for one-off or email-based updates, where each logged entry typically has distinct inputs.

However, during catch-up or batch logging sessions—especially when updating multiple applications for the same company via the company portal—most input fields often remain identical (e.g., only the application date changes). The forced clearing required redundant re-entry of identical information, slowing down the workflow.

---

**Changes**  
- Added a new front-end toggle (`ClearInputsAfterLogging`) to control whether inputs should be reset after logging.  
- Updated `relatedLoggerWorkflow` to conditionally call `resetSheetUI` based on the toggle value.  
- Preserved the previous default behavior (inputs are cleared) when the toggle is enabled.  

---

**Testing**  
- Verified that when `ClearInputsAfterLogging` is checked, inputs are reset as before.  
- Verified that when unchecked, inputs persist after logging, allowing faster batch updates.  

---

**Value**  
This change improves logging efficiency for batch or portal-based updates by allowing users to retain their current inputs when desired, while still maintaining the original safeguard against stale data for standard workflows.